### PR TITLE
Removing animations for exercise one

### DIFF
--- a/components/SlidingRowView/index.tsx
+++ b/components/SlidingRowView/index.tsx
@@ -21,7 +21,7 @@ export default class SlidingRowView extends React.PureComponent<Props> {
     // We need 2 animations to run in parallel
     // 1. Translates the X component of the position to 0
     // 2. Transforms the opacity of the Animated.View from 0.5 to 1.0
-    // They both should last 50ms and should use one `easing` option
+    // They both should last 75ms and should use one `easing` option
     // Extra kudos if you use `interpolate` for the opacity one    
   }
 

--- a/components/SlidingRowView/index.tsx
+++ b/components/SlidingRowView/index.tsx
@@ -7,37 +7,31 @@ interface Props extends RowViewProps {
   style?: StyleProp<ViewStyle>;
 }
 
-const initialPosition = -200;
-
-export default class SlidingRowView extends React.PureComponent<Props> {  
-  position = new Animated.Value(initialPosition);
-  opacity = new Animated.Value(0.5);
+export default class SlidingRowView extends React.PureComponent<Props> {
+  // TODO: Think what values makes sense for your animation
+  position = new Animated.Value(0);
+  opacity = new Animated.Value(1.0);
 
   componentDidMount() {
     this.animateAddOperation();
   }
 
   animateAddOperation() {
-    Animated.parallel([
-      Animated.timing(this.position, {
-        toValue: 0,
-        duration: 50,
-        easing: Easing.ease
-      }),
-      Animated.timing(this.opacity, {
-        toValue: 1,
-        duration: 50,
-        easing: Easing.ease
-      })
-    ]).start();
+    // TODO: Create the animation
+    // We need 2 animations to run in parallel
+    // 1. Translates the X component of the position to 0
+    // 2. Transforms the opacity of the Animated.View from 0.5 to 1.0
+    // They both should last 50ms and should use one `easing` option
+    // Extra kudos if you use `interpolate` for the opacity one    
   }
 
   animateRemoveOperation(onEnd?: () => void) {
-    Animated.timing(this.position, {
-      toValue: initialPosition,
-      duration: 75,
-      easing: Easing.ease
-    }).start(onEnd);
+    // TODO: Create the animation
+    // 1. We need to run a single animation that moves the position of the row
+    // outside the screen.
+    // 2. The animations lasts 75ms.
+    // 3. onEnd callback is called at the end of the animation
+    onEnd && onEnd();
   }
 
   render() {

--- a/storybook/stories/index.tsx
+++ b/storybook/stories/index.tsx
@@ -11,11 +11,11 @@ import GrowAndDisappear from "./GrowAndDisappear";
 import Banner from "./Banner";
 
 storiesOf("Row Animation", module).
-  add("Appear from the top", () => (
-    <TopToBottomRowAnimation />
-  ))
-  .add("Appear from the left", () => (
+  add("Appear from the left", () => (
     <LeftToRightRowAnimation />
+  ))
+  .add("Appear from the top", () => (
+    <TopToBottomRowAnimation />
   ));
 
 const dimensions = Dimensions.get("window");


### PR DESCRIPTION
This PR removes the implementation of the animation to show rows from left to right.

It also changes the order of the row animations in the stories